### PR TITLE
Updating homebridge version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "engines": {
     "node": ">=0.12.0",
-    "homebridge": "1.6.0"
+     "homebridge": ">=1.6.0"
   },
   "dependencies": {
     "request": "^2.85.0"


### PR DESCRIPTION
The current plugin gives a warning when you update to 1.6.1 of homebridge