### PR TITLE
Add DisplayName

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "homebridge-powerview-2",
+  "displayName": "PowerView Shades 2",
   "version": "1.0.9",
   "description": "Updated Homebridge plugin for Hunter Douglas PowerView shades",
   "license": "ISC",


### PR DESCRIPTION
The display name is not currently configured. This PR adds `displayName` to package.json to make the name shown in the HomeBridge UI prettier.

![Screenshot 2023-12-18 at 18 42 34](https://github.com/owenselles/homebridge-powerview-2/assets/591634/25db6663-b286-402e-b040-dfc37e276f12)
