### PR TITLE
Allow higher versions of homebridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "engines": {
     "node": ">=0.12.0",
-    "homebridge": "1.6.0"
+    "homebridge": "^1.6.0"
   },
   "dependencies": {
     "request": "^2.85.0"


### PR DESCRIPTION
On Homebridge 1.7.0, this warning is thrown:

```
The plugin "homebridge-powerview-2" requires a Homebridge version of 1.6.0 which does not satisfy the current Homebridge version of 1.7.0. You may need to update this plugin (or Homebridge) to a newer version. You may face unexpected issues or stability problems running this plugin.
```

I presume all minor/patch bumps to Homebridge will work fine with this plugin, so this PR turns the strict dependency on v1.6.0 into a more loose ^1.6.0 while allows all versions between v1.6.0 - v2.0.0. This will remove the scary red warning for folks on a higher version of Homebridge than 1.6.0.